### PR TITLE
fix: Static export - display actual dashboard content

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,22 +3,21 @@
 import type { DashboardData } from '@/lib/types';
 import { ProjectCard } from '@/components/ProjectCard';
 import { MetricCard } from '@/components/MetricCard';
+import { fetchAllProjects } from '@/lib/github';
+import { TRACKED_PROJECTS } from '@/config/projects';
 
 async function getDashboardData(): Promise<DashboardData> {
   try {
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-    const res = await fetch(`${baseUrl}/api/projects`, {
-      next: { revalidate: 3600 } // Cache for 1 hour
-    });
+    // Fetch directly from GitHub API at build time (for static export)
+    const projects = await fetchAllProjects(TRACKED_PROJECTS);
     
-    if (!res.ok) {
-      throw new Error('Failed to fetch projects');
-    }
-    
-    return res.json();
+    return {
+      projects,
+      lastUpdated: new Date().toISOString()
+    };
   } catch (error) {
     console.error('Error fetching dashboard data:', error);
-    // Return empty data on error
+    // Return empty data on error (graceful fallback)
     return {
       projects: [],
       lastUpdated: new Date().toISOString()
@@ -155,7 +154,11 @@ export default async function Home() {
               GitHub Projects API
             </a>
             {' • '}
-            Updates hourly
+            Built at {new Date(data.lastUpdated).toLocaleString('en-US', {
+              month: 'short',
+              day: 'numeric',
+              year: 'numeric'
+            })}
           </p>
         </div>
       </div>


### PR DESCRIPTION
## 🐛 Critical Fix

Fixes the 'Hello World' issue on Cloudflare Pages deployment.

---

## Issue

Dashboard was showing only 'Hello World' instead of actual content.

**Root Cause:**
- `app/page.tsx` tried to `fetch('/api/projects')` during build
- No server runs during static export (`next build`)
- Fetch failed → empty page → default 'Hello World' displayed

---

## Solution

**Fetch GitHub data directly at build time:**
- Import `fetchAllProjects()` and `TRACKED_PROJECTS` directly
- No HTTP fetch during build
- Data baked into static HTML
- API route still available (but not used during build)

---

## Testing

✅ Local build successful:
```bash
npm run build
# ✓ Compiled successfully
# ✓ Generating static pages (5/5)
# ✓ Exporting (3/3)
```

✅ Output verified:
- `out/index.html` contains actual dashboard content
- 'PM Dashboard' text present
- 'Executive Metrics' section included
- Project cards rendered

---

## Changes

- `app/page.tsx`: Fetch from GitHub API directly (not via /api/projects)

**Before:**
```typescript
const res = await fetch(`${baseUrl}/api/projects`);
```

**After:**
```typescript
const projects = await fetchAllProjects(TRACKED_PROJECTS);
```

---

## Deployment

Merge this PR → Cloudflare auto-rebuilds → Dashboard displays correctly

**No manual steps needed** - Cloudflare will detect the push and rebuild automatically.

---

**Fixes:** 'Hello World' display issue  
**Related:** PR #5 (deployment config)